### PR TITLE
Updating Playbook Widget v 1.0.1 to v1.1.0, showing error Not Found

### DIFF
--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -44,15 +44,11 @@
             });
           });
           createPlaybookButtons(actionPlaybookList);
-        }else {
-          toaster.error({
-            body: 'No results found'
-          })
         }
       }, function(){
         toaster.error({
           body: 'No results found'
-        })
+        });
       });
     }
 


### PR DESCRIPTION
### Description:
Updating Playbook Widget v 1.0.1 to v1.1.0, showing error Not Found

Fixed Details - 
Removed toaster error

### Mantis:
https://mantis.fortinet.com/bug_view_page.php?bug_id=1177754