### PR TITLE
Initial Commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Release Information
 
-- **Version**: 1.1.0
+- **Version**: 1.1.1
 
 - **Certified**: Yes
 

--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -6,11 +6,11 @@
 (function () {
   angular
     .module('cybersponse')
-    .controller('editPlaybookButtons110Ctrl', editPlaybookButtons110Ctrl);
+    .controller('editPlaybookButtons111Ctrl', editPlaybookButtons111Ctrl);
 
-  editPlaybookButtons110Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', 'FormEntityService', 'currentPermissionsService', 'playbookService', '_'];
+  editPlaybookButtons111Ctrl.$inject = ['$scope', '$uibModalInstance', 'config', 'FormEntityService', 'currentPermissionsService', 'playbookService', '_'];
 
-  function editPlaybookButtons110Ctrl($scope, $uibModalInstance, config, FormEntityService, currentPermissionsService, playbookService, _) {
+  function editPlaybookButtons111Ctrl($scope, $uibModalInstance, config, FormEntityService, currentPermissionsService, playbookService, _) {
     $scope.cancel = cancel;
     $scope.save = save;
     $scope.config = config;

--- a/widget/info.json
+++ b/widget/info.json
@@ -2,15 +2,15 @@
     "name": "playbookButtons",
     "title": "Playbook Buttons",
     "subTitle": "The Playbook Buttons widget creates playbook buttons on a records detailed view",
-    "version": "1.1.0",
-    "published_date": 1724842953,
+    "version": "1.1.1",
+    "published_date": 1753961672,
     "releaseNotes": "available",
     "metadata": {
         "description": "The Playbook Buttons widget adds playbooks as separate buttons on a records detailed view that can be executed directly from the records' view panel",
-        "help_online": "https://github.com/fortinet-fortisoar/widget-playbook-buttons/blob/release/1.1.0/README.md",
+        "help_online": "https://github.com/fortinet-fortisoar/widget-playbook-buttons/blob/release/1.1.1/README.md",
         "snapshots": [
-            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookButtons-1.1.0\/images\/playbook_buttons_view.png",
-            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookButtons-1.1.0\/images\/playbook_buttons_edit.png"
+            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookButtons-1.1.1\/images\/playbook_buttons_view.png",
+            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookButtons-1.1.1\/images\/playbook_buttons_edit.png"
         ],
         "pages": [
             "View Panel"

--- a/widget/release_notes.md
+++ b/widget/release_notes.md
@@ -2,4 +2,4 @@
 
 ## Minor Bug Fixes
 
-- Optimized the code for improved performance and added search functionality in the dropdown to enable quick and efficient playbook search.
+- Enabled conditional display of the playbook button depending on the configured trigger step.

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -6,11 +6,11 @@
 (function () {
   angular
     .module('cybersponse')
-    .controller('playbookButtons110Ctrl', playbookButtons110Ctrl);
+    .controller('playbookButtons111Ctrl', playbookButtons111Ctrl);
 
-  playbookButtons110Ctrl.$inject = ['$scope', '_', 'currentPermissionsService', 'FormEntityService', 'playbookService', '$filter', 'widgetService', 'API', '$resource', 'widgetBasePath', 'toaster'];
+  playbookButtons111Ctrl.$inject = ['$scope', '_', 'currentPermissionsService', 'FormEntityService', 'playbookService', '$filter', 'widgetService', 'API', '$resource', 'widgetBasePath', 'toaster'];
 
-  function playbookButtons110Ctrl($scope, _, currentPermissionsService, FormEntityService, playbookService, $filter, widgetService, API, $resource, widgetBasePath, toaster) {
+  function playbookButtons111Ctrl($scope, _, currentPermissionsService, FormEntityService, playbookService, $filter, widgetService, API, $resource, widgetBasePath, toaster) {
     $scope.actionButtonPlaybooks = [];
     $scope.recordPlaybooks = [];
     $scope.widgetBasePath = widgetBasePath;
@@ -28,14 +28,13 @@
       playbookService.detachPaybookStatusWebsocket($scope.playbookStatusSubscription);
     });
 
-    function renderActionButtons() {
+    function renderActionButtons(entity) {
       let actionPlaybookList = [];
-      let playbookIDs = _.pluck($scope.config.selectedPlaybooksWithRecord, 'uuid');
-      playbookService.getPlaybooksData(playbookIDs, ['name', 'triggerStep', 'steps', 'recordTags']).then(function (results) {
-        if(results && results['hydra:member'] && results['hydra:member'].length > 0) {
-          angular.forEach(results['hydra:member'], function(playbookRecord) {
-            angular.forEach($scope.config.selectedPlaybooksWithRecord, function(playbookConfig) {
-              if(playbookConfig.uuid === playbookRecord.uuid) {
+      playbookService.getActionPlaybooks(entity, true).then(function (results) {
+        if (results && results.length > 0) {
+          angular.forEach(results, function (playbookRecord) {
+            angular.forEach($scope.config.selectedPlaybooksWithRecord, function (playbookConfig) {
+              if (playbookConfig.uuid === playbookRecord.uuid && playbookRecord._hide === false) {
                 playbookRecord.icon = playbookConfig.icon;
                 playbookRecord.collectionName = playbookConfig.collectionName;
                 playbookRecord.actionTriggerName = playbookConfig.actionTriggerName;
@@ -45,9 +44,9 @@
           });
           createPlaybookButtons(actionPlaybookList);
         }
-      }, function(){
+      }, function () {
         toaster.error({
-          body: 'No results found'
+          body: 'No playbooks found'
         });
       });
     }


### PR DESCRIPTION
1193828 | Updated renderActionButtons() method to enabled conditional display of the playbook button depending on the configured trigger step

UTC: Updated code using BYOW functionality and tested. 

- Two playbooks were configured with visibility conditions:
   - Playbook 1: Should appear only when the alert severity is Low.
   - Playbook 2: Should appear only when the alert severity is Medium.
- Both playbooks were added to the Alert Detail view using the widget.
- Observed Behavior (UTC):
   - Regardless of alert severity, both playbook buttons are visible for every alert record.
- Expected Behavior (UTC):
   - For alerts with Low severity: Only Playbook 1 should be visible.
   - For alerts with Medium severity: Only Playbook 2 should be visible.